### PR TITLE
Fix the issue of km_resizeTransitionNavigationBarFrame when the view …

### DIFF
--- a/KMNavigationBarTransition/UIViewController+KMNavigationBarTransition.m
+++ b/KMNavigationBarTransition/UIViewController+KMNavigationBarTransition.m
@@ -98,6 +98,7 @@
     if (!self.navigationController.navigationBar) {
         return;
     }
+    [self km_adjustScrollViewContentOffsetIfNeeded];
     UINavigationBar *bar = [[UINavigationBar alloc] init];
     bar.barStyle = self.navigationController.navigationBar.barStyle;
     if (bar.translucent != self.navigationController.navigationBar.translucent) {
@@ -111,6 +112,23 @@
     [self km_resizeTransitionNavigationBarFrame];
     if (!self.navigationController.navigationBarHidden && !self.navigationController.navigationBar.hidden) {
         [self.view addSubview:self.km_transitionNavigationBar];
+    }
+}
+
+- (void)km_adjustScrollViewContentOffsetIfNeeded {
+    if ([self.view isKindOfClass:[UIScrollView class]]) {
+        UIScrollView *scrollView = (UIScrollView *)self.view;
+        const CGFloat topContentOffsetY = -scrollView.contentInset.top;
+        const CGFloat bottomContentOffsetY = scrollView.contentSize.height - (CGRectGetHeight(scrollView.bounds) - scrollView.contentInset.bottom);
+        
+        CGPoint adjustedContentOffset = scrollView.contentOffset;
+        if (adjustedContentOffset.y > bottomContentOffsetY) {
+            adjustedContentOffset.y = bottomContentOffsetY;
+        }
+        if (adjustedContentOffset.y < topContentOffsetY) {
+            adjustedContentOffset.y = topContentOffsetY;
+        }
+        [scrollView setContentOffset:adjustedContentOffset animated:NO];
     }
 }
 


### PR DESCRIPTION
If the current view is UIScrollView, when `km_resizeTransitionNavigationBarFrame` is called, the scrollview's content offset may not be finalized (For example, if you try to to drag the scrollview hardly and swipe to dismiss the current view controller immediately), in this case the position of the navigation bar will be wrong.

The fix here is to change the scrollview's content offset to the final value if it's invalid.

Before this fix:
![break2](https://cloud.githubusercontent.com/assets/927162/16247586/40c762b6-37bf-11e6-870a-d930c2d6e5d8.gif)

After this fix:
![after2](https://cloud.githubusercontent.com/assets/927162/16247659/ad15f5a4-37bf-11e6-9995-bd23ee7a4bae.gif)

