### PR TITLE
(WIP) Replace private API calls

### DIFF
--- a/KMNavigationBarTransition/UIViewController+KMNavigationBarTransition.m
+++ b/KMNavigationBarTransition/UIViewController+KMNavigationBarTransition.m
@@ -87,8 +87,11 @@
     if (!self.view.window) {
         return;
     }
-    UIView *backgroundView = [self.navigationController.navigationBar valueForKey:@"_backgroundView"];
-    CGRect rect = [backgroundView.superview convertRect:backgroundView.frame toView:self.view];
+    
+    CGRect rect = self.navigationController.navigationBar.frame;
+    rect.size.height = CGRectGetHeight(rect) + CGRectGetMinY(rect);
+    rect.origin.y = 0;
+    rect = [self.navigationController.navigationBar.superview convertRect:rect toView:self.view];
     self.km_transitionNavigationBar.frame = rect;
 }
 


### PR DESCRIPTION
I noticed that in `- (void)km_resizeTransitionNavigationBarFrame`, there's a call to private API:
```objc
UIView *backgroundView = [self.navigationController.navigationBar valueForKey:@"_backgroundView"];
```

I think it's best that we should avoid calling private APIs – since in the future it _might_ lead to app rejections, or there could be breaking changes. 

The alternative method uses `navigationBar`'s frame, and the status bar height information is taken from the `navigationBar`'s min Y. If the status bar is hidden, then the navigation bar's `origin.y` will be 0.

Another case is in `- (void)setKm_prefersNavigationBarBackgroundViewHidden:(BOOL)hidden`. The only way I can think of is via `.subviews.firstObject` (although this is basically the same way). Still thinking of an alternative way.

### Tested Scenarios

- Normal navigation (VC with nav bar -> VC with nav bar)
- Navigation to VC with hidden nav bar
- Normal navigation from scroll view
- Navigation to VC with hidden nav bar from scroll view
- Normal navigation with disabled status bar
- Navigation to VC with hidden nav bar, with disabled status bar

Let me know if I miss any other scenarios / edge cases. Thanks!