### PR TITLE
ios11中普通scrollview的适配

### DIFF
--- a/KMNavigationBarTransition/UIViewController+KMNavigationBarTransition.h
+++ b/KMNavigationBarTransition/UIViewController+KMNavigationBarTransition.h
@@ -25,4 +25,6 @@
 
 @interface UIViewController (KMNavigationBarTransition)
 
+@property (nonatomic, weak) UIScrollView *km_scrollView;
+
 @end


### PR DESCRIPTION
大部分的界面应该都是继承自UIViewController，原来只判断self.view的做法，适配起来比较麻烦，