### PR TITLE
Queue transition navigation bar removal on main queue (fixes #107)

### DIFF
--- a/KMNavigationBarTransition/UIViewController+KMNavigationBarTransition.m
+++ b/KMNavigationBarTransition/UIViewController+KMNavigationBarTransition.m
@@ -75,8 +75,10 @@
         [self.navigationController.navigationBar setBackgroundImage:[self.km_transitionNavigationBar backgroundImageForBarMetrics:UIBarMetricsDefault] forBarMetrics:UIBarMetricsDefault];
         [self.navigationController.navigationBar setShadowImage:self.km_transitionNavigationBar.shadowImage];
         if (!transitionViewController || [transitionViewController isEqual:self]) {
-            [self.km_transitionNavigationBar removeFromSuperview];
-            self.km_transitionNavigationBar = nil; 
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self.km_transitionNavigationBar removeFromSuperview];
+                self.km_transitionNavigationBar = nil;
+            });
         }
     }
     if ([transitionViewController isEqual:self]) {


### PR DESCRIPTION
I am experiencing a similar case to #107. 

However, I did find a repro step – In my case, the flashing happens when navigating from a View Controller with translucent`YES` to `NO`, and there's a `layoutIfNeeded` call somewhere in the `viewDidAppear` on the pushed view controller.