### PR TITLE
fix nav titleColor mistake when use bar's titleTextAttributes after p…

### DIFF
--- a/KMNavigationBarTransition.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/KMNavigationBarTransition.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/KMNavigationBarTransition/UINavigationController+KMNavigationBarTransition.m
+++ b/KMNavigationBarTransition/UINavigationController+KMNavigationBarTransition.m
@@ -94,6 +94,7 @@
         self.navigationBar.barTintColor = appearingNavigationBar.barTintColor;
         [self.navigationBar setBackgroundImage:[appearingNavigationBar backgroundImageForBarMetrics:UIBarMetricsDefault] forBarMetrics:UIBarMetricsDefault];
         self.navigationBar.shadowImage = appearingNavigationBar.shadowImage;
+        [self.navigationBar setTitleTextAttributes:appearingNavigationBar.titleTextAttributes];
     }
     if (animated) {
         disappearingViewController.navigationController.km_backgroundViewHidden = YES;

--- a/KMNavigationBarTransition/UIViewController+KMNavigationBarTransition.m
+++ b/KMNavigationBarTransition/UIViewController+KMNavigationBarTransition.m
@@ -135,6 +135,7 @@
     bar.barTintColor = self.navigationController.navigationBar.barTintColor;
     [bar setBackgroundImage:[self.navigationController.navigationBar backgroundImageForBarMetrics:UIBarMetricsDefault] forBarMetrics:UIBarMetricsDefault];
     bar.shadowImage = self.navigationController.navigationBar.shadowImage;
+    [bar setTitleTextAttributes:self.navigationController.navigationBar.titleTextAttributes];
     [self.km_transitionNavigationBar removeFromSuperview];
     self.km_transitionNavigationBar = bar;
     [self km_resizeTransitionNavigationBarFrame];


### PR DESCRIPTION
…ush/pop.

修复了在push/pop后导航条标题颜色错误的显示。（当使用navBar的titleAttribute来控制标题颜色时）