### PR TITLE
Proof of concept opt-in navigation modification (use KMNavigationController)

### DIFF
--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/Example/MainViewController.swift
+++ b/Example/MainViewController.swift
@@ -122,14 +122,14 @@ extension MainViewController {
                 switch (selectedIndexPath.section, selectedIndexPath.row) {
                 case (0, 0):
                     colorsArray = NavigationBarData.BarTintColorArray
-                    selectedIndex = colorsArray.index(of: NavigationBarBackgroundViewColor(rawValue: nextNavigationBarTintColorText.text!)!)
+                    selectedIndex = colorsArray.firstIndex(of: NavigationBarBackgroundViewColor(rawValue: nextNavigationBarTintColorText.text!)!)
                     block = {
                         self.nextNavigationBarData.barTintColor = $0
                         self.nextNavigationBarTintColorText.text = $0.rawValue
                     }
                 case (0, 1):
                     colorsArray = NavigationBarData.BackgroundImageColorArray
-                    selectedIndex = colorsArray.index(of: NavigationBarBackgroundViewColor(rawValue: nextNavigatioBarBackgroundImageColorText.text!)!)
+                    selectedIndex = colorsArray.firstIndex(of: NavigationBarBackgroundViewColor(rawValue: nextNavigatioBarBackgroundImageColorText.text!)!)
                     block = {
                         self.nextNavigationBarData.backgroundImageColor = $0
                         self.nextNavigatioBarBackgroundImageColorText.text = $0.rawValue

--- a/Example/NavigationController.swift
+++ b/Example/NavigationController.swift
@@ -7,6 +7,8 @@
 //
 
 import UIKit
+import KMNavigationBarTransition
+
 
 class NavigationController: UINavigationController {
 

--- a/KMNavigationBarTransition.xcodeproj/project.pbxproj
+++ b/KMNavigationBarTransition.xcodeproj/project.pbxproj
@@ -21,15 +21,15 @@
 		CDC01B971E5CA42000F6F3E2 /* KMNavigationBarTransition.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC01B901E5CA42000F6F3E2 /* KMNavigationBarTransition.framework */; };
 		CDC01B981E5CA42000F6F3E2 /* KMNavigationBarTransition.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CDC01B901E5CA42000F6F3E2 /* KMNavigationBarTransition.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CDC01B9D1E5CA46400F6F3E2 /* KMNavigationBarTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = CDC01B9C1E5CA46400F6F3E2 /* KMNavigationBarTransition.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CDC01B9F1E5CA48400F6F3E2 /* UINavigationController+KMNavigationBarTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = CDDFA1F31C3921BD00BFBA1B /* UINavigationController+KMNavigationBarTransition.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CDC01B9F1E5CA48400F6F3E2 /* KMNavigationController+KMNavigationBarTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = CDDFA1F31C3921BD00BFBA1B /* KMNavigationController+KMNavigationBarTransition.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CDC01BA11E5CA48900F6F3E2 /* UIViewController+KMNavigationBarTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = CDDFA1F51C3921BD00BFBA1B /* UIViewController+KMNavigationBarTransition.h */; };
 		CDC01BA21E5CA48B00F6F3E2 /* UIViewController+KMNavigationBarTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = CDDFA1F61C3921BD00BFBA1B /* UIViewController+KMNavigationBarTransition.m */; };
 		CDC01BA31E5CA48D00F6F3E2 /* KMWeakObjectContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = CDC1BA0C1CE1DFE8006BE1B6 /* KMWeakObjectContainer.h */; };
 		CDC01BA41E5CA48F00F6F3E2 /* KMWeakObjectContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = CDC1BA0D1CE1DFE8006BE1B6 /* KMWeakObjectContainer.m */; };
 		CDC01BA51E5CA49100F6F3E2 /* KMSwizzle.h in Headers */ = {isa = PBXBuildFile; fileRef = CDDFA1F11C3921BD00BFBA1B /* KMSwizzle.h */; };
 		CDC01BA61E5CA49300F6F3E2 /* KMSwizzle.m in Sources */ = {isa = PBXBuildFile; fileRef = CDDFA1F21C3921BD00BFBA1B /* KMSwizzle.m */; };
-		CDC01BA71E5CA67A00F6F3E2 /* UINavigationController+KMNavigationBarTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = CDDFA1F41C3921BD00BFBA1B /* UINavigationController+KMNavigationBarTransition.m */; };
-		CDC01BAA1E5CA82800F6F3E2 /* UINavigationController+KMNavigationBarTransition_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = CDC01BA81E5CA82800F6F3E2 /* UINavigationController+KMNavigationBarTransition_internal.h */; };
+		CDC01BA71E5CA67A00F6F3E2 /* KMNavigationController+KMNavigationBarTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = CDDFA1F41C3921BD00BFBA1B /* KMNavigationController+KMNavigationBarTransition.m */; };
+		CDC01BAA1E5CA82800F6F3E2 /* KMNavigationController+KMNavigationBarTransition_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = CDC01BA81E5CA82800F6F3E2 /* KMNavigationController+KMNavigationBarTransition_internal.h */; };
 		CDC722AD1F7257EE0077084B /* UINavigationBar+KMNavigationBarTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = CDC722AB1F7257EE0077084B /* UINavigationBar+KMNavigationBarTransition.h */; };
 		CDC722AE1F7257EE0077084B /* UINavigationBar+KMNavigationBarTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = CDC722AC1F7257EE0077084B /* UINavigationBar+KMNavigationBarTransition.m */; };
 		CDC722B01F72590C0077084B /* UINavigationBar+KMNavigationBarTransition_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = CDC722AF1F72590C0077084B /* UINavigationBar+KMNavigationBarTransition_internal.h */; };
@@ -37,6 +37,8 @@
 		CDC722B41F72599F0077084B /* NSObject+KMNavigationBarTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = CDC722B21F72599F0077084B /* NSObject+KMNavigationBarTransition.m */; };
 		CDD35A4C1F94CABE00EFDBD8 /* UIScrollView+KMNavigationBarTransition_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD35A4B1F94CABE00EFDBD8 /* UIScrollView+KMNavigationBarTransition_internal.h */; };
 		CDE74D821F7A457C003052BE /* UIScrollView+KMNavigationBarTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = CDE74D811F7A457C003052BE /* UIScrollView+KMNavigationBarTransition.m */; };
+		D0DC046B2269545B004DB6F5 /* KMNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = D0DC04672269545B004DB6F5 /* KMNavigationController.m */; };
+		D0DC046C2269545B004DB6F5 /* KMNavigationController.h in Headers */ = {isa = PBXBuildFile; fileRef = D0DC04682269545B004DB6F5 /* KMNavigationController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,7 +81,7 @@
 		CDC01B901E5CA42000F6F3E2 /* KMNavigationBarTransition.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KMNavigationBarTransition.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDC01B9C1E5CA46400F6F3E2 /* KMNavigationBarTransition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KMNavigationBarTransition.h; sourceTree = "<group>"; };
 		CDC01B9E1E5CA46900F6F3E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		CDC01BA81E5CA82800F6F3E2 /* UINavigationController+KMNavigationBarTransition_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UINavigationController+KMNavigationBarTransition_internal.h"; sourceTree = "<group>"; };
+		CDC01BA81E5CA82800F6F3E2 /* KMNavigationController+KMNavigationBarTransition_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "KMNavigationController+KMNavigationBarTransition_internal.h"; sourceTree = "<group>"; };
 		CDC1BA0C1CE1DFE8006BE1B6 /* KMWeakObjectContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KMWeakObjectContainer.h; sourceTree = "<group>"; };
 		CDC1BA0D1CE1DFE8006BE1B6 /* KMWeakObjectContainer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KMWeakObjectContainer.m; sourceTree = "<group>"; };
 		CDC722AB1F7257EE0077084B /* UINavigationBar+KMNavigationBarTransition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UINavigationBar+KMNavigationBarTransition.h"; sourceTree = "<group>"; };
@@ -90,12 +92,14 @@
 		CDD35A4B1F94CABE00EFDBD8 /* UIScrollView+KMNavigationBarTransition_internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIScrollView+KMNavigationBarTransition_internal.h"; sourceTree = "<group>"; };
 		CDDFA1F11C3921BD00BFBA1B /* KMSwizzle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KMSwizzle.h; sourceTree = "<group>"; };
 		CDDFA1F21C3921BD00BFBA1B /* KMSwizzle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KMSwizzle.m; sourceTree = "<group>"; };
-		CDDFA1F31C3921BD00BFBA1B /* UINavigationController+KMNavigationBarTransition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UINavigationController+KMNavigationBarTransition.h"; sourceTree = "<group>"; };
-		CDDFA1F41C3921BD00BFBA1B /* UINavigationController+KMNavigationBarTransition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UINavigationController+KMNavigationBarTransition.m"; sourceTree = "<group>"; };
+		CDDFA1F31C3921BD00BFBA1B /* KMNavigationController+KMNavigationBarTransition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "KMNavigationController+KMNavigationBarTransition.h"; sourceTree = "<group>"; };
+		CDDFA1F41C3921BD00BFBA1B /* KMNavigationController+KMNavigationBarTransition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "KMNavigationController+KMNavigationBarTransition.m"; sourceTree = "<group>"; };
 		CDDFA1F51C3921BD00BFBA1B /* UIViewController+KMNavigationBarTransition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+KMNavigationBarTransition.h"; sourceTree = "<group>"; };
 		CDDFA1F61C3921BD00BFBA1B /* UIViewController+KMNavigationBarTransition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+KMNavigationBarTransition.m"; sourceTree = "<group>"; };
 		CDE74D801F7A457C003052BE /* UIScrollView+KMNavigationBarTransition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIScrollView+KMNavigationBarTransition.h"; sourceTree = "<group>"; };
 		CDE74D811F7A457C003052BE /* UIScrollView+KMNavigationBarTransition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIScrollView+KMNavigationBarTransition.m"; sourceTree = "<group>"; };
+		D0DC04672269545B004DB6F5 /* KMNavigationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KMNavigationController.m; sourceTree = "<group>"; };
+		D0DC04682269545B004DB6F5 /* KMNavigationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KMNavigationController.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -172,9 +176,11 @@
 		CDDFA1F01C3921BD00BFBA1B /* KMNavigationBarTransition */ = {
 			isa = PBXGroup;
 			children = (
-				CDC01BA81E5CA82800F6F3E2 /* UINavigationController+KMNavigationBarTransition_internal.h */,
-				CDDFA1F31C3921BD00BFBA1B /* UINavigationController+KMNavigationBarTransition.h */,
-				CDDFA1F41C3921BD00BFBA1B /* UINavigationController+KMNavigationBarTransition.m */,
+				D0DC04682269545B004DB6F5 /* KMNavigationController.h */,
+				D0DC04672269545B004DB6F5 /* KMNavigationController.m */,
+				CDC01BA81E5CA82800F6F3E2 /* KMNavigationController+KMNavigationBarTransition_internal.h */,
+				CDDFA1F31C3921BD00BFBA1B /* KMNavigationController+KMNavigationBarTransition.h */,
+				CDDFA1F41C3921BD00BFBA1B /* KMNavigationController+KMNavigationBarTransition.m */,
 				CDAA3BB21E5CB40E00666BB0 /* UIViewController+KMNavigationBarTransition_internal.h */,
 				CDDFA1F51C3921BD00BFBA1B /* UIViewController+KMNavigationBarTransition.h */,
 				CDDFA1F61C3921BD00BFBA1B /* UIViewController+KMNavigationBarTransition.m */,
@@ -203,11 +209,12 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D0DC046C2269545B004DB6F5 /* KMNavigationController.h in Headers */,
 				CDC01B9D1E5CA46400F6F3E2 /* KMNavigationBarTransition.h in Headers */,
 				CDC722B31F72599F0077084B /* NSObject+KMNavigationBarTransition.h in Headers */,
-				CDC01BAA1E5CA82800F6F3E2 /* UINavigationController+KMNavigationBarTransition_internal.h in Headers */,
+				CDC01BAA1E5CA82800F6F3E2 /* KMNavigationController+KMNavigationBarTransition_internal.h in Headers */,
 				CDAA3BB31E5CB40E00666BB0 /* UIViewController+KMNavigationBarTransition_internal.h in Headers */,
-				CDC01B9F1E5CA48400F6F3E2 /* UINavigationController+KMNavigationBarTransition.h in Headers */,
+				CDC01B9F1E5CA48400F6F3E2 /* KMNavigationController+KMNavigationBarTransition.h in Headers */,
 				CDC722B01F72590C0077084B /* UINavigationBar+KMNavigationBarTransition_internal.h in Headers */,
 				CDD35A4C1F94CABE00EFDBD8 /* UIScrollView+KMNavigationBarTransition_internal.h in Headers */,
 				CD4209391F7A47CF00A1EAF5 /* UIScrollView+KMNavigationBarTransition.h in Headers */,
@@ -270,7 +277,7 @@
 				TargetAttributes = {
 					CDA3726E1C3907CE00E39A6D = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0820;
+						LastSwiftMigration = 1020;
 					};
 					CDC01B8F1E5CA42000F6F3E2 = {
 						CreatedOnToolsVersion = 8.2.1;
@@ -283,6 +290,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -339,9 +347,10 @@
 				CDC01BA41E5CA48F00F6F3E2 /* KMWeakObjectContainer.m in Sources */,
 				CDC722AE1F7257EE0077084B /* UINavigationBar+KMNavigationBarTransition.m in Sources */,
 				CDC01BA61E5CA49300F6F3E2 /* KMSwizzle.m in Sources */,
-				CDC01BA71E5CA67A00F6F3E2 /* UINavigationController+KMNavigationBarTransition.m in Sources */,
+				CDC01BA71E5CA67A00F6F3E2 /* KMNavigationController+KMNavigationBarTransition.m in Sources */,
 				CDC01BA21E5CA48B00F6F3E2 /* UIViewController+KMNavigationBarTransition.m in Sources */,
 				CDE74D821F7A457C003052BE /* UIScrollView+KMNavigationBarTransition.m in Sources */,
+				D0DC046B2269545B004DB6F5 /* KMNavigationController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -472,7 +481,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mo.KMNavigationBarTransition-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -485,7 +494,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mo.KMNavigationBarTransition-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/KMNavigationBarTransition/KMNavigationBarTransition.h
+++ b/KMNavigationBarTransition/KMNavigationBarTransition.h
@@ -31,4 +31,6 @@ FOUNDATION_EXPORT const unsigned char KMNavigationBarTransitionVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <KMNavigationBarTransition/PublicHeader.h>
 
-#import <KMNavigationBarTransition/UINavigationController+KMNavigationBarTransition.h>
+#import <KMNavigationBarTransition/KMNavigationController.h>
+//#import <KMNavigationBarTransition/KMViewController.h>
+#import <KMNavigationBarTransition/KMNavigationController+KMNavigationBarTransition.h>

--- a/KMNavigationBarTransition/KMNavigationController+KMNavigationBarTransition.h
+++ b/KMNavigationBarTransition/KMNavigationController+KMNavigationBarTransition.h
@@ -22,8 +22,9 @@
 //  THE SOFTWARE.
 
 #import <UIKit/UIKit.h>
+#import "KMNavigationController.h"
 
-@interface UINavigationController (KMNavigationBarTransition)
+@interface KMNavigationController (KMNavigationBarTransition)
 
 // By default this is white, it is related to issue with transparent navigationBar
 - (UIColor *)km_containerViewBackgroundColor;

--- a/KMNavigationBarTransition/KMNavigationController+KMNavigationBarTransition.m
+++ b/KMNavigationBarTransition/KMNavigationController+KMNavigationBarTransition.m
@@ -21,15 +21,17 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#import "UINavigationController+KMNavigationBarTransition.h"
-#import "UINavigationController+KMNavigationBarTransition_internal.h"
+#import "KMNavigationController+KMNavigationBarTransition.h"
+#import "KMNavigationController+KMNavigationBarTransition_internal.h"
 #import "UIViewController+KMNavigationBarTransition.h"
 #import "UIViewController+KMNavigationBarTransition_internal.h"
 #import "KMWeakObjectContainer.h"
 #import <objc/runtime.h>
 #import "KMSwizzle.h"
+//#import "KMNavigationController.h"
+//#import "KMViewController.h"
 
-@implementation UINavigationController (KMNavigationBarTransition)
+@implementation KMNavigationController (KMNavigationBarTransition)
 
 + (void)load {
     static dispatch_once_t onceToken;
@@ -76,7 +78,7 @@
     if (animated) {
         self.km_transitionContextToViewController = viewController;
         if (disappearingViewController.km_transitionNavigationBar) {
-            disappearingViewController.navigationController.km_backgroundViewHidden = YES;
+            ((KMNavigationController *) disappearingViewController.navigationController).km_backgroundViewHidden = YES;
         }
     }
     return [self km_pushViewController:viewController animated:animated];
@@ -96,7 +98,7 @@
         self.navigationBar.shadowImage = appearingNavigationBar.shadowImage;
     }
     if (animated) {
-        disappearingViewController.navigationController.km_backgroundViewHidden = YES;
+        ((KMNavigationController *) disappearingViewController.navigationController).km_backgroundViewHidden = YES;
     }
     return [self km_popViewControllerAnimated:animated];
 }
@@ -114,7 +116,7 @@
         self.navigationBar.shadowImage = appearingNavigationBar.shadowImage;
     }
     if (animated) {
-        disappearingViewController.navigationController.km_backgroundViewHidden = YES;
+        ((KMNavigationController *) disappearingViewController.navigationController).km_backgroundViewHidden = YES;
     }
     return [self km_popToViewController:viewController animated:animated];
 }
@@ -133,7 +135,7 @@
         self.navigationBar.shadowImage = appearingNavigationBar.shadowImage;
     }
     if (animated) {
-        disappearingViewController.navigationController.km_backgroundViewHidden = YES;
+        ((KMNavigationController *) disappearingViewController.navigationController).km_backgroundViewHidden = YES;
     }
     return [self km_popToRootViewControllerAnimated:animated];
 }
@@ -143,7 +145,7 @@
     if (animated && disappearingViewController && ![disappearingViewController isEqual:viewControllers.lastObject]) {
         [disappearingViewController km_addTransitionNavigationBarIfNeeded];
         if (disappearingViewController.km_transitionNavigationBar) {
-            disappearingViewController.navigationController.km_backgroundViewHidden = YES;
+            ((KMNavigationController *) disappearingViewController.navigationController).km_backgroundViewHidden = YES;
         }
     }
     return [self km_setViewControllers:viewControllers animated:animated];

--- a/KMNavigationBarTransition/KMNavigationController+KMNavigationBarTransition_internal.h
+++ b/KMNavigationBarTransition/KMNavigationController+KMNavigationBarTransition_internal.h
@@ -22,8 +22,9 @@
 //  THE SOFTWARE.
 
 #import <UIKit/UIKit.h>
+#import "KMNavigationController.h"
 
-@interface UINavigationController (KMNavigationBarTransition_internal)
+@interface KMNavigationController (KMNavigationBarTransition_internal)
 
 @property (nonatomic, assign) BOOL km_backgroundViewHidden;
 @property (nonatomic, weak) UIViewController *km_transitionContextToViewController;

--- a/KMNavigationBarTransition/KMNavigationController.h
+++ b/KMNavigationBarTransition/KMNavigationController.h
@@ -1,0 +1,12 @@
+//
+//  KMNavigationController.h
+//  KMNavigationBarTransition
+//
+//  Created by Eliah Snakin on 19/04/2019.
+//  Copyright © 2019 Zhouqi Mo. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface KMNavigationController : UINavigationController
+@end

--- a/KMNavigationBarTransition/KMNavigationController.m
+++ b/KMNavigationBarTransition/KMNavigationController.m
@@ -1,0 +1,13 @@
+//
+//  KMNavigationController.m
+//  KMNavigationBarTransition
+//
+//  Created by Eliah Snakin on 19/04/2019.
+//  Copyright © 2019 Zhouqi Mo. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "KMNavigationController.h"
+
+@implementation KMNavigationController
+@end

--- a/KMNavigationBarTransition/NSObject+KMNavigationBarTransition.m
+++ b/KMNavigationBarTransition/NSObject+KMNavigationBarTransition.m
@@ -22,7 +22,7 @@
 //  THE SOFTWARE.
 
 #import "NSObject+KMNavigationBarTransition.h"
-#import "UINavigationController+KMNavigationBarTransition_internal.h"
+#import "KMNavigationController+KMNavigationBarTransition_internal.h"
 #import "UINavigationBar+KMNavigationBarTransition_internal.h"
 #import <objc/runtime.h>
 #import "KMSwizzle.h"
@@ -45,8 +45,8 @@
         if ([responder isKindOfClass:[UINavigationBar class]] && ((UINavigationBar *)responder).km_isFakeBar) {
             return;
         }
-        if ([responder isKindOfClass:[UINavigationController class]]) {
-            [self km_setHidden:((UINavigationController *)responder).km_backgroundViewHidden];
+        if ([responder isKindOfClass:[KMNavigationController class]]) {
+            [self km_setHidden:((KMNavigationController *)responder).km_backgroundViewHidden];
             return;
         }
         responder = responder.nextResponder;


### PR DESCRIPTION
Because sometimes in complex VCs' hierarchies there happen to be bugs, and because giving a choice is generally considered a good practice (especially with such a crucial system component as navigation controller), I propose to create an opt-in version of this beautiful library.
My proposal is basically a hack (plus the last time I've been using obj-c was 4 years ago), but you can notice that there is a new `KMNavigationController` class, and modifications are applied only if this `UINavigationController` subclass is being used. 
THE PROPOSED CODE REQUIRES HEAVY REFACTORING. Sorry for that, needed it fast.
Thank you for your consideration.
Swizzle responsibly! :P