### PR TITLE
Determine whether the km_transitionNavigationBar is added successfull…

### DIFF
--- a/KMNavigationBarTransition/UINavigationController+KMNavigationBarTransition.m
+++ b/KMNavigationBarTransition/UINavigationController+KMNavigationBarTransition.m
@@ -94,9 +94,9 @@
         self.navigationBar.barTintColor = appearingNavigationBar.barTintColor;
         [self.navigationBar setBackgroundImage:[appearingNavigationBar backgroundImageForBarMetrics:UIBarMetricsDefault] forBarMetrics:UIBarMetricsDefault];
         self.navigationBar.shadowImage = appearingNavigationBar.shadowImage;
-    }
-    if (animated) {
-        disappearingViewController.navigationController.km_backgroundViewHidden = YES;
+        if (animated) {
+            disappearingViewController.navigationController.km_backgroundViewHidden = YES;
+        }
     }
     return [self km_popViewControllerAnimated:animated];
 }
@@ -112,9 +112,9 @@
         self.navigationBar.barTintColor = appearingNavigationBar.barTintColor;
         [self.navigationBar setBackgroundImage:[appearingNavigationBar backgroundImageForBarMetrics:UIBarMetricsDefault] forBarMetrics:UIBarMetricsDefault];
         self.navigationBar.shadowImage = appearingNavigationBar.shadowImage;
-    }
-    if (animated) {
-        disappearingViewController.navigationController.km_backgroundViewHidden = YES;
+        if (animated) {
+            disappearingViewController.navigationController.km_backgroundViewHidden = YES;
+        }
     }
     return [self km_popToViewController:viewController animated:animated];
 }


### PR DESCRIPTION
…y before hidding the background view of the system's navigation bar when poping

原有的问题。比如一个tabbarVC作为rootVC, 有两个tab，tabA 和tabB, 分别有各自的NavA-VCA，NavB-VCB,  app启动的时候，VCB是没有load的。在VCA页面 直接跳转tabB的二级页面的时候先把tabbar index设置成1，然后再push 另一个VCD，因为VCB没有load所以在push的时候没有添加fakeBar,但是之后从VCD返回VCB的时候因为没有判断是否有fakeBar就去隐藏了原生的导航栏导致导航栏会闪一下。