### PR TITLE
修复iOS15系统下UINavigationBarAppearance其他属性丢失的问题

### DIFF
--- a/KMNavigationBarTransition.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/KMNavigationBarTransition.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/KMNavigationBarTransition/UIViewController+KMNavigationBarTransition.m
+++ b/KMNavigationBarTransition/UIViewController+KMNavigationBarTransition.m
@@ -141,15 +141,7 @@
         bar.translucent = self.navigationController.navigationBar.translucent;
     }
     if (@available(iOS 15, *)) {
-        UINavigationBarAppearance *navigationBarAppearance = [UINavigationBarAppearance new];
-        if (bar.translucent) {
-            [navigationBarAppearance configureWithTransparentBackground];
-        } else {
-            [navigationBarAppearance configureWithOpaqueBackground];
-        }
-        navigationBarAppearance.backgroundColor = self.navigationController.navigationBar.standardAppearance.backgroundColor;
-        navigationBarAppearance.backgroundImage = self.navigationController.navigationBar.standardAppearance.backgroundImage;
-        navigationBarAppearance.shadowImage = self.navigationController.navigationBar.standardAppearance.shadowImage;
+        UINavigationBarAppearance *navigationBarAppearance = [[UINavigationBarAppearance alloc] initWithBarAppearance:self.navigationController.navigationBar.standardAppearance];
         bar.standardAppearance = navigationBarAppearance;
         bar.scrollEdgeAppearance = navigationBarAppearance;
     } else {


### PR DESCRIPTION
iOS15下如果设置了导航栏其他属性，如titleTextAttributes等，会丢失。km_addTransitionNavigationBarIfNeeded需要对用户设置的所有self.navigationController.navigationBar.standardAppearance的属性进行copy